### PR TITLE
Add global Perses dashboards and update version to 1.5.3

### DIFF
--- a/charts/ceph-operations/Chart.yaml
+++ b/charts/ceph-operations/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ceph-operations
 description: Ceph operations bundle
 type: application
-version: 1.5.2
+version: 1.5.3

--- a/charts/ceph-operations/perses-dashboards-global/ceph-capacity-quick-view.json
+++ b/charts/ceph-operations/perses-dashboards-global/ceph-capacity-quick-view.json
@@ -1,0 +1,370 @@
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "ceph-capacity-quick-view",
+    "project": "ceph_global"
+  },
+  "spec": {
+    "display": {
+      "name": "ceph capacity quick view"
+    },
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Ceph Capacity"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Region",
+                  "hide": false,
+                  "name": "region"
+                },
+                {
+                  "header": "Cluster Capacity",
+                  "name": "value #1"
+                },
+                {
+                  "header": "Resource Usage (%",
+                  "name": "value #3"
+                },
+                {
+                  "header": "Resource Usage (%)",
+                  "name": "value #4"
+                },
+                {
+                  "header": "Quota Size",
+                  "name": "value #2"
+                },
+                {
+                  "hide": true,
+                  "name": "timestamp"
+                },
+                {
+                  "hide": true,
+                  "name": "__name__"
+                },
+                {
+                  "hide": true,
+                  "name": "cluster"
+                },
+                {
+                  "hide": true,
+                  "name": "cluster_type"
+                },
+                {
+                  "hide": true,
+                  "name": "container"
+                },
+                {
+                  "hide": true,
+                  "name": "endpoint"
+                },
+                {
+                  "hide": true,
+                  "name": "instance"
+                },
+                {
+                  "hide": true,
+                  "name": "job"
+                },
+                {
+                  "hide": true,
+                  "name": "namespace"
+                },
+                {
+                  "hide": true,
+                  "name": "organization"
+                },
+                {
+                  "hide": true,
+                  "name": "pod"
+                },
+                {
+                  "hide": true,
+                  "name": "prometheus"
+                },
+                {
+                  "hide": true,
+                  "name": "rgw_cluster_id"
+                },
+                {
+                  "header": "user",
+                  "name": "user"
+                },
+                {
+                  "hide": true,
+                  "name": "service"
+                }
+              ],
+              "density": "compact",
+              "transforms": [
+                {
+                  "kind": "MergeSeries",
+                  "spec": {}
+                },
+                {
+                  "kind": "JoinByColumnValue",
+                  "spec": {
+                    "columns": ["region"]
+                  }
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceph_cluster_total_bytes",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceph_cluster_total_used_bytes",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "1 - (ceph_cluster_total_bytes - ceph_cluster_total_used_bytes) / ceph_cluster_total_bytes",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Ceph Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Region",
+                  "name": "region"
+                },
+                {
+                  "header": "",
+                  "name": "Time 1"
+                },
+                {
+                  "header": "Capacity",
+                  "name": "value #1"
+                },
+                {
+                  "header": "Quota Usage",
+                  "name": "value #2"
+                },
+                {
+                  "header": "Unassigned Quota",
+                  "name": "value #3"
+                },
+                {
+                  "header": "Resource Usage",
+                  "name": "value #4"
+                },
+                {
+                  "header": "Quota Usage %",
+                  "name": "value #5"
+                },
+                {
+                  "header": "Resource Usage %",
+                  "name": "value #6"
+                },
+                {
+                  "hide": true,
+                  "name": "timestamp"
+                },
+                {
+                  "hide": true,
+                  "name": "Time 1"
+                },
+                {
+                  "hide": true,
+                  "name": "Time 2"
+                },
+                {
+                  "hide": true,
+                  "name": "Time 3"
+                },
+                {
+                  "hide": true,
+                  "name": "Time 4"
+                },
+                {
+                  "hide": true,
+                  "name": "Time 5"
+                },
+                {
+                  "hide": true,
+                  "name": "Time 6"
+                },
+                {
+                  "hide": false,
+                  "name": "Value #A"
+                },
+                {
+                  "name": "Quota Usage %"
+                },
+                {
+                  "name": "Resource Usage %"
+                },
+                {
+                  "name": "Region"
+                }
+              ],
+              "density": "compact",
+              "transforms": [
+                {
+                  "kind": "MergeSeries",
+                  "spec": {}
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(max(global:limes_consolidated_cluster_capacity{full_resource=~\"ceph/(.*)\"}) by (region) *\n max(global:limes_consolidated_unit_multiplier{full_resource=~\"ceph/(.*)\"}) by (region))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(sum(global:limes_consolidated_domain_quota{full_resource=~\"ceph/(.*)\"}) by (region) *\n max(global:limes_consolidated_unit_multiplier{full_resource=~\"ceph/(.*)\"}) by (region))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(max(global:limes_consolidated_cluster_capacity{full_resource=~\"ceph/(.*)\"}) by (region) *\n max(global:limes_consolidated_unit_multiplier{full_resource=~\"ceph/(.*)\"}) by (region)) -\n(sum(global:limes_consolidated_domain_quota{full_resource=~\"ceph/(.*)\"}) by (region) *\n max(global:limes_consolidated_unit_multiplier{full_resource=~\"ceph/(.*)\"}) by (region))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(sum(global:limes_consolidated_domain_usage{full_resource=~\"ceph/(.*)\"}) by (region) *\n max(global:limes_consolidated_unit_multiplier{full_resource=~\"ceph/(.*)\"}) by (region))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(sum(global:limes_consolidated_domain_quota{full_resource=~\"ceph/(.*)\"}) by (region) *\n max(global:limes_consolidated_unit_multiplier{full_resource=~\"ceph/(.*)\"}) by (region)) / (max(global:limes_consolidated_cluster_capacity{full_resource=~\"ceph/(.*)\"}) by (region) *\n max(global:limes_consolidated_unit_multiplier{full_resource=~\"ceph/(.*)\"}) by (region))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(sum(global:limes_consolidated_domain_usage{full_resource=~\"ceph/(.*)\"}) by (region) *\n max(global:limes_consolidated_unit_multiplier{full_resource=~\"ceph/(.*)\"}) by (region)) / (max(global:limes_consolidated_cluster_capacity{full_resource=~\"ceph/(.*)\"}) by (region) *\n max(global:limes_consolidated_unit_multiplier{full_resource=~\"ceph/(.*)\"}) by (region))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 24,
+              "height": 16,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "variables": [],
+    "duration": "1h",
+    "refreshInterval": "0s",
+    "datasources": {}
+  }
+}

--- a/charts/ceph-operations/perses-dashboards-global/ceph-health-quick-view.json
+++ b/charts/ceph-operations/perses-dashboards-global/ceph-health-quick-view.json
@@ -1,0 +1,311 @@
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "ceph-health-quick-view",
+    "project": "ceph_global"
+  },
+  "spec": {
+    "display": {
+      "name": "ceph health quick view"
+    },
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Ceph Health"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "cellSettings": [
+                {
+                  "condition": {
+                    "kind": "Misc",
+                    "spec": {
+                      "value": "null"
+                    }
+                  },
+                  "text": "0"
+                }
+              ],
+              "columnSettings": [
+                {
+                  "header": "Region",
+                  "hide": false,
+                  "name": "region"
+                },
+                {
+                  "header": "Health Status",
+                  "name": "value #1"
+                },
+                {
+                  "header": "Ceph Alerts",
+                  "name": "value #2"
+                },
+                {
+                  "header": "Write Throughput",
+                  "name": "value #3"
+                },
+                {
+                  "header": "Read Throughput",
+                  "name": "value #4"
+                },
+                {
+                  "header": "Write IOPs",
+                  "name": "value #5"
+                },
+                {
+                  "header": "Read IOPs",
+                  "name": "value #6"
+                },
+                {
+                  "header": "OSDs OUT",
+                  "name": "value #7"
+                },
+                {
+                  "header": "OSDs DOWN",
+                  "name": "value #8"
+                },
+                {
+                  "header": "OSDs UP",
+                  "name": "value #9"
+                },
+                {
+                  "header": "OSDs IN",
+                  "name": "value #10"
+                },
+                {
+                  "hide": true,
+                  "name": "timestamp"
+                },
+                {
+                  "hide": true,
+                  "name": "__name__"
+                },
+                {
+                  "hide": true,
+                  "name": "cluster"
+                },
+                {
+                  "hide": true,
+                  "name": "cluster_type"
+                },
+                {
+                  "hide": true,
+                  "name": "container"
+                },
+                {
+                  "hide": true,
+                  "name": "endpoint"
+                },
+                {
+                  "hide": true,
+                  "name": "instance"
+                },
+                {
+                  "hide": true,
+                  "name": "job"
+                },
+                {
+                  "hide": true,
+                  "name": "namespace"
+                },
+                {
+                  "hide": true,
+                  "name": "organization"
+                },
+                {
+                  "hide": true,
+                  "name": "pod"
+                },
+                {
+                  "hide": true,
+                  "name": "prometheus"
+                },
+                {
+                  "hide": true,
+                  "name": "rgw_cluster_id"
+                },
+                {
+                  "header": "user",
+                  "name": "user"
+                },
+                {
+                  "hide": true,
+                  "name": "service"
+                }
+              ],
+              "density": "standard",
+              "transforms": [
+                {
+                  "kind": "MergeSeries",
+                  "spec": {}
+                },
+                {
+                  "kind": "JoinByColumnValue",
+                  "spec": {
+                    "columns": ["region"]
+                  }
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceph_health_status",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "count(ALERTS{alertstate=\"firing\",alertname=~\"^Ceph.+\"}) by (region)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(ceph_osd_op_w_in_bytes{}[$__rate_interval])) by (region)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(ceph_osd_op_r_out_bytes{}[$__rate_interval])) by (region)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(ceph_osd_op_w{}[$__rate_interval])) by (region)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(ceph_osd_op_r{}[$__rate_interval])) by (region)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(ceph_osd_in == bool 0) by (region)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(ceph_osd_up == bool 0) by (region)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(ceph_osd_up) by (region)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(ceph_osd_in) by (region)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 18,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "variables": [],
+    "duration": "1h",
+    "refreshInterval": "0s"
+  }
+}

--- a/charts/ceph-operations/perses-dashboards-global/project.json
+++ b/charts/ceph-operations/perses-dashboards-global/project.json
@@ -1,0 +1,7 @@
+{
+  "kind": "Project",
+  "metadata": {
+    "name": "ceph-global"
+  },
+  "spec": { "display": { "name": "Ceph Global" } }
+}

--- a/charts/ceph-operations/templates/_helpers.tpl
+++ b/charts/ceph-operations/templates/_helpers.tpl
@@ -48,6 +48,16 @@ app.cloud-storage.io/part-of: {{ $root.Release.Name }}
 {{- end }}
 {{- end }}
 
+{{- define "cloud-storage-operations.persesGlobalDashboardSelectorLabels" }}
+{{- $path := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if $root.Values.dashboards.global.persesDashboardSelectors }}
+{{- range $i, $target := $root.Values.dashboards.global.persesDashboardSelectors }}
+{{ $target.name | required (printf "$.Values.dashboards.global.persesDashboardSelectors.[%v].name missing" $i) }}: {{ tpl ($target.value | required (printf "$.Values.dashboards.global.persesDashboardSelectors.[%v].value missing" $i)) $ }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "cloud-storage-operations.persesDashboardSelectorLabels" }}
 {{- $path := index . 0 -}}
 {{- $root := index . 1 -}}

--- a/charts/ceph-operations/templates/ceph-perses-dashboards.yaml
+++ b/charts/ceph-operations/templates/ceph-perses-dashboards.yaml
@@ -14,3 +14,20 @@ data:
 {{ printf "%s" $bytes | indent 4 }}
 {{- end }}
 {{- end }}
+
+{{- if .Values.dashboards.global.create }}
+{{ $root := . }}
+{{- range $path, $bytes := .Files.Glob "perses-dashboards-global/*.json" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" $root.Release.Name ($path | replace ".json" "" | replace "/" "-" | trunc 63) }}
+  labels:
+{{- include "cloud-storage-operations.persesGlobalDashboardSelectorLabels" (list $path $root) | indent 4 }} 
+{{ include "cloud-storage-operations.labels" (list $path $root) | indent 4 }}
+data:     
+{{ printf "%s: |-" ($path | replace "/" "-" | indent 2) }}
+{{ printf "%s" $bytes | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/ceph-operations/values.yaml
+++ b/charts/ceph-operations/values.yaml
@@ -10,7 +10,7 @@ global:
 ##
 prometheusRules:
   ## Enables PrometheusRule resources to be created
-  create: true 
+  create: true
 
   ## PrometheusRule groups to be created
   ruleGroups:
@@ -72,6 +72,11 @@ dashboards:
     ## Label selectors for the global Plutono dashboards to be picked up by the global Plutono.
     dashboardSelectors:
       - name: plutono-global
+        value: '"true"'
+
+    ## Label selectors for the global Perses dashboards to be picked up by the global Perses.
+    persesDashboardSelectors:
+      - name: perses.dev/global-resource
         value: '"true"'
 
 ## Create default perses dashboards for monitoring the cluster


### PR DESCRIPTION
With this PR, 
Global Plutono dashboards are migrated to Perses. 

## Known Limitations
Column units are currently not supported in the Perses. This is a temporary limitation that will be addressed in an upcoming Perses release. https://github.com/perses/plugins/pull/87#issuecomment-2783537559
## Next Steps
I will create a follow-up PR once column unit support is available in the next Perses version to complete the migration with full feature parity.

Signed-off-by: Akshay Iyyadurai Balasundaram <akshay.iyyadurai.balasundaram@sap.com>