### PR TITLE
Fix Perses project reference from dashboards

### DIFF
--- a/charts/ceph-operations/Chart.yaml
+++ b/charts/ceph-operations/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ceph-operations
 description: Ceph operations bundle
 type: application
-version: 1.5.3
+version: 1.5.4

--- a/charts/ceph-operations/perses-dashboards-global/ceph-capacity-quick-view.json
+++ b/charts/ceph-operations/perses-dashboards-global/ceph-capacity-quick-view.json
@@ -2,7 +2,7 @@
   "kind": "Dashboard",
   "metadata": {
     "name": "ceph-capacity-quick-view",
-    "project": "ceph_global"
+    "project": "ceph-global"
   },
   "spec": {
     "display": {

--- a/charts/ceph-operations/perses-dashboards-global/ceph-health-quick-view.json
+++ b/charts/ceph-operations/perses-dashboards-global/ceph-health-quick-view.json
@@ -2,7 +2,7 @@
   "kind": "Dashboard",
   "metadata": {
     "name": "ceph-health-quick-view",
-    "project": "ceph_global"
+    "project": "ceph-global"
   },
   "spec": {
     "display": {

--- a/charts/ceph-operations/plugindefinition.yaml
+++ b/charts/ceph-operations/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: ceph-operations
 spec:
-  version: 1.5.3
+  version: 1.5.4
   displayName: Ceph operations bundle
   description: Operations bundle for the Ceph storage backend
   docMarkDownUrl: https://raw.githubusercontent.com/cobaltcore-dev/cloud-storage-operations/main/ceph-operations/README.md
@@ -14,7 +14,7 @@ spec:
   helmChart:
     name: ceph-operations
     repository: oci://ghcr.io/cobaltcore-dev/cloud-storage-operations/charts
-    version: 1.5.3
+    version: 1.5.4
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules


### PR DESCRIPTION
Bump the version of the ceph-operations bundle and update project names reference.