### PR TITLE
ceph-rgw-overview: various updates

### DIFF
--- a/charts/ceph-operations/Chart.yaml
+++ b/charts/ceph-operations/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ceph-operations
 description: Ceph operations bundle
 type: application
-version: 1.6.0
+version: 1.6.1

--- a/charts/ceph-operations/perses-dashboards/ceph-rgw-overview.json
+++ b/charts/ceph-operations/perses-dashboards/ceph-rgw-overview.json
@@ -1742,7 +1742,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Objects Per Bucket"
+            "name": "Top 10 - Objects Per Bucket"
           },
           "plugin": {
             "kind": "BarChart",
@@ -1767,8 +1767,8 @@
                       "kind": "PrometheusDatasource"
                     },
                     "minStep": "",
-                    "query": "sort_desc(radosgw_usage_bucket_objects)",
-                    "seriesNameFormat": "{{bucket}}"
+                    "query": "topk(10, radosgw_usage_bucket_objects)",
+                    "seriesNameFormat": "{{bucket}} - {{owner}}"
                   }
                 }
               }
@@ -2327,6 +2327,13 @@
               "legend": {
                 "position": "bottom"
               },
+              "thresholds": {
+                "steps": [
+                  {
+                    "value": 0.15
+                  }
+                ]
+              },
               "visual": {
                 "areaOpacity": 0.1,
                 "connectNulls": false,
@@ -2339,13 +2346,6 @@
                 },
                 "label": "",
                 "show": true
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "value": 0.15
-                  }
-                ]
               }
             }
           },
@@ -2377,6 +2377,13 @@
               "legend": {
                 "position": "bottom"
               },
+              "thresholds": {
+                "steps": [
+                  {
+                    "value": 0.15
+                  }
+                ]
+              },
               "visual": {
                 "areaOpacity": 0.1,
                 "connectNulls": false,
@@ -2389,13 +2396,6 @@
                 },
                 "label": "",
                 "show": true
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "value": 0.15
-                  }
-                ]
               }
             }
           },
@@ -2427,6 +2427,13 @@
               "legend": {
                 "position": "bottom"
               },
+              "thresholds": {
+                "steps": [
+                  {
+                    "value": 0.15
+                  }
+                ]
+              },
               "visual": {
                 "areaOpacity": 0.1,
                 "connectNulls": false,
@@ -2439,13 +2446,6 @@
                 },
                 "label": "",
                 "show": true
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "value": 0.15
-                  }
-                ]
               }
             }
           },
@@ -2477,6 +2477,13 @@
               "legend": {
                 "position": "bottom"
               },
+              "thresholds": {
+                "steps": [
+                  {
+                    "value": 0.15
+                  }
+                ]
+              },
               "visual": {
                 "areaOpacity": 0.1,
                 "connectNulls": false,
@@ -2489,13 +2496,6 @@
                 },
                 "label": "",
                 "show": true
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "value": 0.15
-                  }
-                ]
               }
             }
           },
@@ -2527,6 +2527,13 @@
               "legend": {
                 "position": "bottom"
               },
+              "thresholds": {
+                "steps": [
+                  {
+                    "value": 0.15
+                  }
+                ]
+              },
               "visual": {
                 "areaOpacity": 0.1,
                 "connectNulls": false,
@@ -2539,13 +2546,6 @@
                 },
                 "label": "",
                 "show": true
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "value": 0.15
-                  }
-                ]
               }
             }
           },

--- a/charts/ceph-operations/plugindefinition.yaml
+++ b/charts/ceph-operations/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: ceph-operations
 spec:
-  version: 1.6.0
+  version: 1.6.1
   displayName: Ceph operations bundle
   description: Operations bundle for the Ceph storage backend
   docMarkDownUrl: https://raw.githubusercontent.com/cobaltcore-dev/cloud-storage-operations/main/ceph-operations/README.md
@@ -14,7 +14,7 @@ spec:
   helmChart:
     name: ceph-operations
     repository: oci://ghcr.io/cobaltcore-dev/cloud-storage-operations/charts
-    version: 1.6.0
+    version: 1.6.1
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules


### PR DESCRIPTION
- [ceph-rgw-overview: Unify graph visualization](https://github.com/cobaltcore-dev/cloud-storage-operations/pull/36/commits/13604665b2c8bea6ba92347833d46adf1cddb841)
- [ceph-rgw-overview: Add Prysm instance queries](https://github.com/cobaltcore-dev/cloud-storage-operations/pull/36/commits/d58e1b136b379cb7334aff8d7c7bd4ae805002c1)
- [ceph-rgw-overview: Split latency panels](https://github.com/cobaltcore-dev/cloud-storage-operations/pull/36/commits/91022e62ab0c6dde1d075775336f0240eb7e16d0)
  Split RGW overview latency panels in order to display one panel per HTTP method.
- [ceph-rgw-overview: Add thresholds](https://github.com/cobaltcore-dev/cloud-storage-operations/pull/36/commits/97ab3c7fc9327afe961a49acee4531233e1ec6f7)
Add thresholds for the following panels:
  - Bucket Latency GET
  - Bucket Latency PUT
  - Bucket Latency POST
  - Bucket Latency DELETE
  - User Latency
- [ceph-rgw-overview: Top 10 - Objects Per Bucket](https://github.com/cobaltcore-dev/cloud-storage-operations/pull/36/commits/04e6d7cfcb2a51731b8d83e34afc91a8f7456b51)
Update "Objects Per Bucket" panel in order to show top 10 buckets.

Fixes:
- https://github.com/cobaltcore-dev/cloud-storage/issues/294