### PR TITLE
(chore): migrate to ClusterPluginDefinition

### DIFF
--- a/charts/ceph-operations/plugindefinition.yaml
+++ b/charts/ceph-operations/plugindefinition.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: greenhouse.sap/v1alpha1
-kind: PluginDefinition
+kind: ClusterPluginDefinition
 metadata:
   name: ceph-operations
 spec:


### PR DESCRIPTION
This PR migrates `PluginDefinition` CR to `ClusterPluginDefinition` CR to be used in greenhouse platform

The issue is documented here https://github.com/cloudoperators/greenhouse/issues/1004 and here https://github.com/cloudoperators/greenhouse/issues/1214

## Breaking Changes

- While this is breaking change, greenhouse controllers ensure smooth transition without any user action necessary