### PR TITLE
ceph-disk-overview: hide unnecessary 'vendor_id'

### DIFF
--- a/charts/ceph-operations/Chart.yaml
+++ b/charts/ceph-operations/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ceph-operations
 description: Ceph operations bundle
 type: application
-version: 1.7.4
+version: 1.7.5
 maintainers:
   - name: sumitarora2786
   - name: richardtief

--- a/charts/ceph-operations/perses-dashboards/ceph-disk-overview.json
+++ b/charts/ceph-operations/perses-dashboards/ceph-disk-overview.json
@@ -1024,7 +1024,7 @@
                   "enableSorting": true,
                   "header": "Vendor",
                   "name": "vendor",
-                  "width": "auto"
+                  "width": 300
                 },
                 {
                   "enableSorting": true,
@@ -1156,6 +1156,10 @@
                 {
                   "hide": true,
                   "name": "attribute"
+                },
+                {
+                  "name": "vendor_id",
+                  "hide": true
                 }
               ],
               "defaultColumnWidth": "auto",

--- a/charts/ceph-operations/plugindefinition.yaml
+++ b/charts/ceph-operations/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: ceph-operations
 spec:
-  version: 1.7.4
+  version: 1.7.5
   displayName: Ceph operations bundle
   description: Operations bundle for the Ceph storage backend
   docMarkDownUrl: https://raw.githubusercontent.com/cobaltcore-dev/cloud-storage-operations/main/ceph-operations/README.md
@@ -14,7 +14,7 @@ spec:
   helmChart:
     name: ceph-operations
     repository: oci://ghcr.io/cobaltcore-dev/cloud-storage-operations/charts
-    version: 1.7.4
+    version: 1.7.5
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules


### PR DESCRIPTION
Hide unnecessary 'vendor_id' column. The vendor ID is already part of the 'vendor' column. We don't need it twice.