### PR TITLE
ceph-disk-overview: separate Vendor column

### DIFF
--- a/charts/ceph-operations/Chart.yaml
+++ b/charts/ceph-operations/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ceph-operations
 description: Ceph operations bundle
 type: application
-version: 1.8.0
+version: 1.8.1
 maintainers:
   - name: sumitarora2786
   - name: richardtief

--- a/charts/ceph-operations/perses-dashboards/ceph-disk-overview.json
+++ b/charts/ceph-operations/perses-dashboards/ceph-disk-overview.json
@@ -1021,10 +1021,14 @@
                   "width": "auto"
                 },
                 {
-                  "enableSorting": true,
-                  "header": "Vendor",
-                  "name": "vendor",
-                  "width": "auto"
+                  "name": "vendor_id",
+                  "header": "Vendor ID",
+                  "enableSorting": true
+                },
+                {
+                  "name": "subsystem_vendor_id",
+                  "header": "Subsystem Vendor ID",
+                  "enableSorting": true
                 },
                 {
                   "enableSorting": true,
@@ -1063,12 +1067,15 @@
                   "name": "value #7"
                 },
                 {
-                  "enableSorting": true,
+                  "header": "Vendor",
+                  "name": "vendor",
+                  "hide": true
+                },
+                {
                   "hide": true,
                   "name": "model"
                 },
                 {
-                  "enableSorting": true,
                   "hide": true,
                   "name": "product"
                 },

--- a/charts/ceph-operations/plugindefinition.yaml
+++ b/charts/ceph-operations/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: ClusterPluginDefinition
 metadata:
   name: ceph-operations
 spec:
-  version: 1.8.0
+  version: 1.8.1
   displayName: Ceph operations bundle
   description: Operations bundle for the Ceph storage backend
   docMarkDownUrl: https://raw.githubusercontent.com/cobaltcore-dev/cloud-storage-operations/main/ceph-operations/README.md
@@ -14,7 +14,7 @@ spec:
   helmChart:
     name: ceph-operations
     repository: oci://ghcr.io/cobaltcore-dev/cloud-storage-operations/charts
-    version: 1.8.0
+    version: 1.8.1
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules


### PR DESCRIPTION
Split the Vendor column in two separate ones: Vendor ID and Subsystem Vendor ID.