### PR TITLE
[ceph-operations] exclude `/dev/loop` in CephNodeRootFilesystemFull

### DIFF
--- a/charts/ceph-operations/Chart.yaml
+++ b/charts/ceph-operations/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ceph-operations
 description: Ceph operations bundle
 type: application
-version: 1.8.19
+version: 1.8.20
 maintainers:
   - name: sumitarora2786
   - name: richardtief

--- a/charts/ceph-operations/alerts/nodes.yaml
+++ b/charts/ceph-operations/alerts/nodes.yaml
@@ -6,7 +6,7 @@ groups:
   rules:
 {{- if not (.Values.prometheusRules.disabled.CephNodeRootFilesystemFull | default false) }}
   - alert: CephNodeRootFilesystemFull
-    expr: node_filesystem_avail_bytes{mountpoint="/", device!~"/dev/loop."} / node_filesystem_size_bytes{mountpoint="/", device!~"/dev/loop."} * 100 < 5
+    expr: node_filesystem_avail_bytes{mountpoint="/", device!~"/dev/loop.*"} / node_filesystem_size_bytes{mountpoint="/", device!~"/dev/loop.*"} * 100 < 5
     for: 5m
     labels:
       service: ceph

--- a/charts/ceph-operations/alerts/nodes.yaml
+++ b/charts/ceph-operations/alerts/nodes.yaml
@@ -6,7 +6,7 @@ groups:
   rules:
 {{- if not (.Values.prometheusRules.disabled.CephNodeRootFilesystemFull | default false) }}
   - alert: CephNodeRootFilesystemFull
-    expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} * 100 < 5
+    expr: node_filesystem_avail_bytes{mountpoint="/", device!~"/dev/loop."} / node_filesystem_size_bytes{mountpoint="/", device!~"/dev/loop."} * 100 < 5
     for: 5m
     labels:
       service: ceph


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the application chart version to 1.8.20 to keep releases current.

* **Bug Fixes**
  * Improved the filesystem-full alert so it no longer triggers for loop-mounted devices, reducing false positives for disk usage monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->