### PR TITLE
Update rgw.yaml adjust rgw alerts

### DIFF
--- a/charts/ceph-operations/Chart.yaml
+++ b/charts/ceph-operations/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ceph-operations
 description: Ceph operations bundle
 type: application
-version: 1.8.25
+version: 1.8.26
 maintainers:
   - name: sumitarora2786
   - name: richardtief

--- a/charts/ceph-operations/alerts/rgw.yaml
+++ b/charts/ceph-operations/alerts/rgw.yaml
@@ -45,7 +45,7 @@ groups:
       /
       sum by (bucket) (
         rate(radosgw_requests_duration_count{method="GET"}[5m])
-      ) > 3
+      ) > 5
     for: 5m
     labels:
       service: ceph
@@ -87,7 +87,7 @@ groups:
       /
       sum by (bucket, method) (
         rate(radosgw_requests_duration_count{method=~"GET|PUT"}[5m])
-      ) > 3
+      ) > 5
     for: 5m
     labels:
       service: ceph
@@ -104,7 +104,7 @@ groups:
     expr: |
       sum by (instance, pod) (
         rate(radosgw_total_requests[5m])
-      ) > 100
+      ) > 500
     for: 5m
     labels:
       service: ceph
@@ -119,10 +119,15 @@ groups:
 {{- if not (.Values.prometheusRules.disabled.RGWUnbalancedLoad | default false) }}
   - alert: RGWUnbalancedLoad
     expr: |
-      sum by (instance) (rate(radosgw_total_requests[5m]))
-      /
-      avg(sum by (instance) (rate(radosgw_total_requests[5m])))
-      > 2
+      (
+        sum by (instance) (rate(radosgw_total_requests[5m]))
+        / scalar(avg(sum by (instance) (rate(radosgw_total_requests[5m]))))
+        > 2
+      )
+      and
+      (
+        sum by (instance) (rate(radosgw_total_requests[5m])) > 20
+      )
     for: 5m
     labels:
       service: ceph
@@ -139,7 +144,7 @@ groups:
     expr: |
       sum by (instance) (
         rate(radosgw_bytes_sent[5m])
-      ) / (1024 * 1024 * 1024) > 1
+      ) / (1024 * 1024 * 1024) > 3
     for: 5m
     labels:
       service: ceph
@@ -154,10 +159,7 @@ groups:
 {{- if not (.Values.prometheusRules.disabled.RGWNodeHighLoad | default false) }}
   - alert: RGWNodeHighLoad
     expr: |
-      node_load5{job="node-exporter"}
-      /
-      (node_load5{job="node-exporter"} offset 5m)
-      >= 2
+      node_load5{job="node-exporter"} > 500
     for: 5m
     labels:
       service: ceph

--- a/charts/ceph-operations/plugindefinition.yaml
+++ b/charts/ceph-operations/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: ceph-operations
 spec:
-  version: 1.8.25
+  version: 1.8.26
   displayName: Ceph operations bundle
   description: Operations bundle for the Ceph storage backend
   docMarkDownUrl: https://raw.githubusercontent.com/cobaltcore-dev/cloud-storage-operations/main/ceph-operations/README.md
@@ -14,7 +14,7 @@ spec:
   helmChart:
     name: ceph-operations
     repository: oci://ghcr.io/cobaltcore-dev/cloud-storage-operations/charts
-    version: 1.8.25
+    version: 1.8.26
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Alert Improvements**
  * Updated Ceph RGW alert thresholds to reduce noise during higher normal workloads.
  * Alerts now account for both relative imbalance and minimum request volume.
  * Revised node load detection to use a fixed high-load threshold.

* **Maintenance**
  * Updated the Ceph operations plugin and Helm chart to version 1.8.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->